### PR TITLE
Bump es6-native-set to v3.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ outside of node and it is a lot faster than native JS implementations.
 As of 2.0.0, requires node.js 0.12 or later. If you are running
 node.js 0.10, stick with the 1.x.x.
 
+As of 3.6.0, es6-native-set implements @@iterator, so you can use all the iterable functions and operators.
+
 ### Usage
 
 ```javascript
@@ -50,6 +52,11 @@ iterator.next(); // { done: true, value: undefined }
 
 set.clear(); // undefined
 set.size; // 0
+
+var setFromArray = new Set([1,2,3]);
+setFromArray.has(1); // true
+Array.from(setFromArray); // [1,2,3]
+[...setFromArray]; // [1,2,3]
 ```
 
 This package is made possible because of [Grokker](http://grokker.com/), one of the best places to work. If you are a JS developer looking for a new gig, send me an email at &#x5b;'chad', String.fromCharCode(64), 'grokker', String.fromCharCode(0x2e), 'com'&#x5d;.join('').

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ set.size; // 0
 
 var setFromArray = new Set([1,2,3]);
 setFromArray.has(1); // true
-Array.from(setFromArray); // [1,2,3]
-[...setFromArray]; // [1,2,3]
+Array.from(setFromArray); // [1,2,3] (order may differ)
+[...setFromArray]; // [1,2,3] (order may differ)
 ```
 
 This package is made possible because of [Grokker](http://grokker.com/), one of the best places to work. If you are a JS developer looking for a new gig, send me an email at &#x5b;'chad', String.fromCharCode(64), 'grokker', String.fromCharCode(0x2e), 'com'&#x5d;.join('').

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "es6-native-set",
-  "version": "3.5.2",
+  "version": "3.6.0",
   "description": "Native es6 set for Node",
   "main": "./index.js",
   "keywords": [

--- a/test/set.test.js
+++ b/test/set.test.js
@@ -173,3 +173,39 @@ const test = require('tape');
   });
 
 });
+
+
+test('test readme code sample', (assert) => {
+  const Set = require('../index.js');
+  let set;
+  assert.doesNotThrow(() => {set = new Set();}, 'can construct new empty Set');
+
+  assert.doesNotThrow(() => {set.add('raz').add('dwa').add({});}, 'can chain add calls to add strings and object');
+  assert.equal(set.size, 3, 'after adding three elements set size is 3');
+  assert.ok(set.has('raz'), 'set has added element');
+  assert.notOk(set.has('foo'), 'set does not have nonexistent element');
+  assert.equals(set.add('foo'), set, 'call to add returns the set object');
+  assert.equals(set.size, 4, 'calling add increments set size by 1');
+  assert.ok(set.has('foo'), 'set has existing element');
+  assert.ok(set.has('dwa'), 'set has existing element');
+  assert.ok(set.delete('dwa'), 'calling delete on existing element returns true');
+  assert.equals(set.size, 3, 'calling delete on existing element decrements set size by 1');
+
+  const elements = [];
+  set.forEach(function (value) {
+    elements.push(value);
+  });
+  assert.equals(elements.filter((v) => ['raz', '[object Object]', 'foo'].indexOf(v.toString()) === -1).length, 0, 'iteration with .forEach includes all values (not preserving insertion order)');
+
+  const iterator = set.values();
+
+  assert.doesNotThrow(() => {iterator.next();}, 'iterator returned by .values() has a next method');
+  assert.equals(iterator.next().done, false, 'iterator returns object with done property set to false while not finished');
+  assert.ok(set.has(iterator.next().value), 'iterator returns set element as the value property ');
+  assert.ok(iterator.next().done && iterator.next().value === undefined, 'done is true and value is undefined when iteration has finished');
+
+  assert.doesNotThrow(() => {set.clear();}, 'can clear set');
+  assert.equal(set.size, 0, 'after clearing set size is 0');
+
+  assert.end();
+});

--- a/test/set.test.js
+++ b/test/set.test.js
@@ -172,46 +172,44 @@ const test = require('tape');
     assert.end();
   });
 
-});
+  test(`test ${setType} readme code sample`, (assert) => {
+      const Set = require('../index.js');
+      let set;
+      assert.doesNotThrow(() => {set = new Set();}, 'can construct new empty Set');
 
+      assert.doesNotThrow(() => {set.add('raz').add('dwa').add({});}, 'can chain add calls to add strings and object');
+      assert.equal(set.size, 3, 'after adding three elements set size is 3');
+      assert.ok(set.has('raz'), 'set has added element');
+      assert.notOk(set.has('foo'), 'set does not have nonexistent element');
+      assert.equals(set.add('foo'), set, 'call to add returns the set object');
+      assert.equals(set.size, 4, 'calling add increments set size by 1');
+      assert.ok(set.has('foo'), 'set has existing element');
+      assert.ok(set.has('dwa'), 'set has existing element');
+      assert.ok(set.delete('dwa'), 'calling delete on existing element returns true');
+      assert.equals(set.size, 3, 'calling delete on existing element decrements set size by 1');
 
-test('test readme code sample', (assert) => {
-  const Set = require('../index.js');
-  let set;
-  assert.doesNotThrow(() => {set = new Set();}, 'can construct new empty Set');
+      const elements = [];
+      set.forEach(function (value) {
+          elements.push(value);
+      });
+      assert.equals(elements.filter((v) => ['raz', '[object Object]', 'foo'].indexOf(v.toString()) === -1).length, 0, 'iteration with .forEach includes all values (not preserving insertion order)');
 
-  assert.doesNotThrow(() => {set.add('raz').add('dwa').add({});}, 'can chain add calls to add strings and object');
-  assert.equal(set.size, 3, 'after adding three elements set size is 3');
-  assert.ok(set.has('raz'), 'set has added element');
-  assert.notOk(set.has('foo'), 'set does not have nonexistent element');
-  assert.equals(set.add('foo'), set, 'call to add returns the set object');
-  assert.equals(set.size, 4, 'calling add increments set size by 1');
-  assert.ok(set.has('foo'), 'set has existing element');
-  assert.ok(set.has('dwa'), 'set has existing element');
-  assert.ok(set.delete('dwa'), 'calling delete on existing element returns true');
-  assert.equals(set.size, 3, 'calling delete on existing element decrements set size by 1');
+      const iterator = set.values();
 
-  const elements = [];
-  set.forEach(function (value) {
-    elements.push(value);
+      assert.doesNotThrow(() => {iterator.next();}, 'iterator returned by .values() has a next method');
+      assert.equals(iterator.next().done, false, 'iterator returns object with done property set to false while not finished');
+      assert.ok(set.has(iterator.next().value), 'iterator returns set element as the value property ');
+      assert.ok(iterator.next().done && iterator.next().value === undefined, 'done is true and value is undefined when iteration has finished');
+
+      assert.doesNotThrow(() => {set.clear();}, 'can clear set');
+      assert.equal(set.size, 0, 'after clearing set size is 0');
+
+      let setFromArray;
+      assert.doesNotThrow(() => {setFromArray = new Set([1,2,3]);}, 'can create set from array');
+      assert.ok(setFromArray.has(1), 'set from array has element of array');
+      assert.deepEquals(Array.from(setFromArray).sort(), [1,2,3], 'can use Array.from() to create array from set (not preserving insertion order)');
+      assert.deepEquals([...setFromArray].sort(), [1,2,3], 'can use spread syntax to create array from set (not preserving insertion order)');
+
+      assert.end();
   });
-  assert.equals(elements.filter((v) => ['raz', '[object Object]', 'foo'].indexOf(v.toString()) === -1).length, 0, 'iteration with .forEach includes all values (not preserving insertion order)');
-
-  const iterator = set.values();
-
-  assert.doesNotThrow(() => {iterator.next();}, 'iterator returned by .values() has a next method');
-  assert.equals(iterator.next().done, false, 'iterator returns object with done property set to false while not finished');
-  assert.ok(set.has(iterator.next().value), 'iterator returns set element as the value property ');
-  assert.ok(iterator.next().done && iterator.next().value === undefined, 'done is true and value is undefined when iteration has finished');
-
-  assert.doesNotThrow(() => {set.clear();}, 'can clear set');
-  assert.equal(set.size, 0, 'after clearing set size is 0');
-
-  let setFromArray;
-  assert.doesNotThrow(() => {setFromArray = new Set([1,2,3]);}, 'can create set from array');
-  assert.ok(setFromArray.has(1), 'set from array has element of array');
-  assert.deepEquals(Array.from(setFromArray).sort(), [1,2,3], 'can use Array.from() to create array from set (not preserving insertion order)');
-  assert.deepEquals([...setFromArray].sort(), [1,2,3], 'can use spread syntax to create array from set (not preserving insertion order)');
-
-  assert.end();
 });

--- a/test/set.test.js
+++ b/test/set.test.js
@@ -207,5 +207,11 @@ test('test readme code sample', (assert) => {
   assert.doesNotThrow(() => {set.clear();}, 'can clear set');
   assert.equal(set.size, 0, 'after clearing set size is 0');
 
+  let setFromArray;
+  assert.doesNotThrow(() => {setFromArray = new Set([1,2,3]);}, 'can create set from array');
+  assert.ok(setFromArray.has(1), 'set from array has element of array');
+  assert.deepEquals(Array.from(setFromArray).sort(), [1,2,3], 'can use Array.from() to create array from set (not preserving insertion order)');
+  assert.deepEquals([...setFromArray].sort(), [1,2,3], 'can use spread syntax to create array from set (not preserving insertion order)');
+
   assert.end();
 });


### PR DESCRIPTION
Document the non-breaking API changes from adding `@@iterator` support by mentioning these in the readme and including new previously-unsupported code samples, adding a test to make sure that all code samples in the readme (old and new) are working as expected.